### PR TITLE
Use the clang from bootstrap instead of the system's one

### DIFF
--- a/gecko-116.0.3/0014-use-clang-from-bootstrap-in-release-tarballs.patch
+++ b/gecko-116.0.3/0014-use-clang-from-bootstrap-in-release-tarballs.patch
@@ -1,0 +1,51 @@
+diff --git a/build/moz.configure/bootstrap.configure b/build/moz.configure/bootstrap.configure
+--- a/build/moz.configure/bootstrap.configure
++++ b/build/moz.configure/bootstrap.configure
+@@ -53,36 +53,28 @@
+         return not bool(include)
+ 
+     return match
+ 
+ 
+-@depends(developer_options, "--enable-bootstrap", moz_fetches_dir)
+-def bootstrap_search_path_order(developer_options, bootstrap, moz_fetches_dir):
++@depends("--enable-bootstrap", moz_fetches_dir)
++def bootstrap_search_path_order(bootstrap, moz_fetches_dir):
++    if not bootstrap and bootstrap.origin != "default":
++        log.debug(
++            "Prioritizing system over mozbuild state dir in "
++            "toolchain paths because you are building with "
++            "bootstrap explicitly disabled."
++        )
++        return "append"
++
+     if moz_fetches_dir:
+         log.debug("Prioritizing MOZ_FETCHES_DIR in toolchain path.")
+-        return "prepend"
++    else:
++        log.debug("Prioritizing mozbuild state dir in toolchain paths.")
+ 
+     if bootstrap:
+-        log.debug(
+-            "Prioritizing mozbuild state dir in toolchain paths because "
+-            "bootstrap mode is enabled."
+-        )
+         return "maybe-prepend"
+-
+-    if developer_options:
+-        log.debug(
+-            "Prioritizing mozbuild state dir in toolchain paths because "
+-            "you are not building in release mode."
+-        )
+-        return "prepend"
+-
+-    log.debug(
+-        "Prioritizing system over mozbuild state dir in "
+-        "toolchain paths because you are building in "
+-        "release mode."
+-    )
+-    return "append"
++    return "prepend"
+ 
+ 
+ toolchains_base_dir = moz_fetches_dir | mozbuild_state_path


### PR DESCRIPTION
Except when bootstrap is explicitly disabled. This means that on --enable-release builds, we would now prefer previously bootstrapped toolchains (but wouldn't bootstrap by default if they aren't there)

This patch has been backported from a bug 1853271 [1], which at the time of this commit is still under review.

[1] https://bugzilla.mozilla.org/show_bug.cgi?id=1853271