### PR TITLE
Add support for MagicLeap2 WebXR input profile

### DIFF
--- a/gecko-116.0.3/0016-webxr-Support-MagicLeap2-controller.patch
+++ b/gecko-116.0.3/0016-webxr-Support-MagicLeap2-controller.patch
@@ -1,0 +1,50 @@
+diff --git a/dom/vr/XRInputSource.cpp b/dom/vr/XRInputSource.cpp
+index 16ff32a40f..f3beef26d9 100644
+--- a/dom/vr/XRInputSource.cpp
++++ b/dom/vr/XRInputSource.cpp
+@@ -126,6 +126,12 @@ nsTArray<nsString> GetInputSourceProfile(gfx::VRControllerType aType) {
+       id.AssignLiteral("generic-trigger-squeeze-thumbstick");
+       profile.AppendElement(id);
+       break;
++    case gfx::VRControllerType::MagicLeap2:
++      id.AssignLiteral("magicleap-one");
++      profile.AppendElement(id);
++      id.AssignLiteral("generic-trigger-squeeze-thumbstick");
++      profile.AppendElement(id);
++      break;
+     default:
+       NS_WARNING("Unsupported XR input source profile.\n");
+       break;
+diff --git a/gfx/vr/VRDisplayClient.cpp b/gfx/vr/VRDisplayClient.cpp
+index 0a949cb913..36a7b5bb71 100644
+--- a/gfx/vr/VRDisplayClient.cpp
++++ b/gfx/vr/VRDisplayClient.cpp
+@@ -436,6 +436,16 @@ void VRDisplayClient::GamepadMappingForWebVR(
+       aControllerState.numButtons = 6;
+       aControllerState.numAxes = 2;
+       break;
++    case VRControllerType::MagicLeap2:
++      aControllerState.buttonPressed = ShiftButtonBitForNewSlot(0, 2) |
++                                       ShiftButtonBitForNewSlot(1, 0) |
++                                       ShiftButtonBitForNewSlot(2, 1);
++      aControllerState.buttonTouched = ShiftButtonBitForNewSlot(0, 2, true) |
++                                       ShiftButtonBitForNewSlot(1, 0, true) |
++                                       ShiftButtonBitForNewSlot(2, 1, true);
++      aControllerState.numButtons = 3;
++      aControllerState.numAxes = 2;
++      break;
+     default:
+       // Undefined controller types, we will keep its the same order.
+       break;
+diff --git a/gfx/vr/external_api/moz_external_vr.h b/gfx/vr/external_api/moz_external_vr.h
+index 031caa2a51..1bb2cdd9f8 100644
+--- a/gfx/vr/external_api/moz_external_vr.h
++++ b/gfx/vr/external_api/moz_external_vr.h
+@@ -153,6 +153,7 @@ enum class VRControllerType : uint8_t {
+   PicoNeo2,
+   Pico4,
+   MetaQuest3,
++  MagicLeap2,
+   _end
+ };
+ 


### PR DESCRIPTION
Adding Gecko support for MagicLeap2 WebXR input profile. There is no public profile for the ML2 yet so we're falling back to using the ML1 instead.