### PR TITLE
Patches for Firefox 127.0.1

### DIFF
--- a/gecko-127.0.1/0001-Use-transform-matrix-for-several-WebXR-pose-calculat.patch
+++ b/gecko-127.0.1/0001-Use-transform-matrix-for-several-WebXR-pose-calculat.patch
@@ -1,0 +1,244 @@
+diff --git a/dom/vr/XRBoundedReferenceSpace.cpp b/dom/vr/XRBoundedReferenceSpace.cpp
+index 8d6eb25fdf..200a2539f8 100644
+--- a/dom/vr/XRBoundedReferenceSpace.cpp
++++ b/dom/vr/XRBoundedReferenceSpace.cpp
+@@ -50,22 +50,14 @@ void XRBoundedReferenceSpace::GetBoundsGeometry(
+ 
+ already_AddRefed<XRReferenceSpace>
+ XRBoundedReferenceSpace::GetOffsetReferenceSpace(
+-    const XRRigidTransform& aOriginOffset) {
++    const XRRigidTransform& aOffsetTransform) {
+   RefPtr<XRBoundedReferenceSpace> offsetReferenceSpace =
+       new XRBoundedReferenceSpace(GetParentObject(), mSession, mNativeOrigin);
+ 
+-  // https://immersive-web.github.io/webxr/#multiply-transforms
+-  // An XRRigidTransform is essentially a rotation followed by a translation
+-  gfx::QuaternionDouble otherOrientation = aOriginOffset.RawOrientation();
+-  // The resulting rotation is the two combined
+-  offsetReferenceSpace->mOriginOffsetOrientation =
+-      mOriginOffsetOrientation * otherOrientation;
+-  // We first apply the rotation of aOriginOffset to
+-  // mOriginOffsetPosition offset, then translate by the offset of
+-  // aOriginOffset
+-  offsetReferenceSpace->mOriginOffsetPosition =
+-      otherOrientation.RotatePoint(mOriginOffsetPosition) +
+-      aOriginOffset.RawPosition();
++  // https://immersive-web.github.io/webxr/#dom-xrreferencespace-getoffsetreferencespace
++  // Set offsetSpace’s origin offset to the result of multiplying base’s origin offset
++  // by originOffset in the relevant realm of base.
++  offsetReferenceSpace->mOriginOffset = mOriginOffset * aOffsetTransform.RawTransform();
+ 
+   return offsetReferenceSpace.forget();
+ }
+diff --git a/dom/vr/XRFrame.cpp b/dom/vr/XRFrame.cpp
+index 639bb2b019..1561d36eb0 100644
+--- a/dom/vr/XRFrame.cpp
++++ b/dom/vr/XRFrame.cpp
+@@ -81,12 +81,7 @@ already_AddRefed<XRViewerPose> XRFrame::GetViewerPose(
+     headTransform.SetRotationFromQuaternion(viewerOrientation);
+     headTransform.PostTranslate(viewerPosition);
+ 
+-    gfx::Matrix4x4Double originTransform;
+-    originTransform.SetRotationFromQuaternion(
+-        aReferenceSpace.GetEffectiveOriginOrientation().Inverse());
+-    originTransform.PreTranslate(-aReferenceSpace.GetEffectiveOriginPosition());
+-
+-    headTransform *= originTransform;
++    headTransform *= aReferenceSpace.GetEffectiveOriginTransform().Inverse();
+ 
+     viewerPose = mSession->PooledViewerPose(headTransform, emulatedPosition);
+ 
+@@ -156,13 +151,9 @@ already_AddRefed<XRPose> XRFrame::GetPose(const XRSpace& aSpace,
+   // TODO (Bug 1616393) - Check if poses must be limited:
+   // https://immersive-web.github.io/webxr/#poses-must-be-limited
+ 
+-  const bool emulatedPosition = aSpace.IsPositionEmulated();
+-  gfx::Matrix4x4Double base;
+-  base.SetRotationFromQuaternion(
+-      aBaseSpace.GetEffectiveOriginOrientation().Inverse());
+-  base.PreTranslate(-aBaseSpace.GetEffectiveOriginPosition());
++  const bool emulatedPosition = aSpace.IsPositionEmulated() || aBaseSpace.IsPositionEmulated();
+ 
+-  gfx::Matrix4x4Double matrix = aSpace.GetEffectiveOriginTransform() * base;
++  gfx::Matrix4x4Double matrix = aSpace.GetEffectiveOriginTransform() * aBaseSpace.GetEffectiveOriginTransform().Inverse();
+ 
+   RefPtr<XRRigidTransform> transform = new XRRigidTransform(mParent, matrix);
+   RefPtr<XRPose> pose = new XRPose(mParent, transform, emulatedPosition);
+diff --git a/dom/vr/XRNativeOriginLocal.cpp b/dom/vr/XRNativeOriginLocal.cpp
+index fd4590cf9e..32f0f3f2ec 100644
+--- a/dom/vr/XRNativeOriginLocal.cpp
++++ b/dom/vr/XRNativeOriginLocal.cpp
+@@ -15,20 +15,7 @@ XRNativeOriginLocal::XRNativeOriginLocal(gfx::VRDisplayClient* aDisplay)
+ }
+ 
+ gfx::PointDouble3D XRNativeOriginLocal::GetPosition() {
+-  // Keep returning {0,0,0} until a position can be found
+-  if (!mInitialPositionValid) {
+-    const gfx::VRHMDSensorState& sensorState = mDisplay->GetSensorState();
+-    gfx::PointDouble3D origin;
+-    if (sensorState.flags & gfx::VRDisplayCapabilityFlags::Cap_Position ||
+-        sensorState.flags &
+-            gfx::VRDisplayCapabilityFlags::Cap_PositionEmulated) {
+-      mInitialPosition.x = sensorState.pose.position[0];
+-      mInitialPosition.y = sensorState.pose.position[1];
+-      mInitialPosition.z = sensorState.pose.position[2];
+-      mInitialPositionValid = true;
+-    }
+-  }
+-  return mInitialPosition;
++  return { };
+ }
+ 
+ }  // namespace mozilla::dom
+diff --git a/dom/vr/XRNativeOriginLocalFloor.cpp b/dom/vr/XRNativeOriginLocalFloor.cpp
+index 2cd146d925..a60a714b0a 100644
+--- a/dom/vr/XRNativeOriginLocalFloor.cpp
++++ b/dom/vr/XRNativeOriginLocalFloor.cpp
+@@ -29,9 +29,9 @@ gfx::PointDouble3D XRNativeOriginLocalFloor::GetPosition() {
+       mDisplay->GetDisplayInfo().GetSittingToStandingTransform();
+   if (!mInitialPositionValid || standing != mStandingTransform) {
+     const gfx::VRHMDSensorState& sensorState = mDisplay->GetSensorState();
+-    mInitialPosition.x = sensorState.pose.position[0];
++    mInitialPosition.x = 0;
+     mInitialPosition.y = -mFloorRandom - standing._42;
+-    mInitialPosition.z = sensorState.pose.position[2];
++    mInitialPosition.z = 0;
+     mInitialPositionValid = true;
+     mStandingTransform = standing;
+   }
+diff --git a/dom/vr/XRReferenceSpace.cpp b/dom/vr/XRReferenceSpace.cpp
+index 9ed73003cd..c442a916c6 100644
+--- a/dom/vr/XRReferenceSpace.cpp
++++ b/dom/vr/XRReferenceSpace.cpp
+@@ -17,22 +17,14 @@ XRReferenceSpace::XRReferenceSpace(nsIGlobalObject* aParent,
+     : XRSpace(aParent, aSession, aNativeOrigin), mType(aType) {}
+ 
+ already_AddRefed<XRReferenceSpace> XRReferenceSpace::GetOffsetReferenceSpace(
+-    const XRRigidTransform& aOriginOffset) {
++    const XRRigidTransform& aOffsetTransform) {
+   RefPtr<XRReferenceSpace> offsetReferenceSpace =
+       new XRReferenceSpace(GetParentObject(), mSession, mNativeOrigin, mType);
+ 
+-  // https://immersive-web.github.io/webxr/#multiply-transforms
+-  // An XRRigidTransform is essentially a rotation followed by a translation
+-  gfx::QuaternionDouble otherOrientation = aOriginOffset.RawOrientation();
+-  // The resulting rotation is the two combined
+-  offsetReferenceSpace->mOriginOffsetOrientation =
+-      mOriginOffsetOrientation * otherOrientation;
+-  // We first apply the rotation of aOriginOffset to
+-  // mOriginOffsetPosition offset, then translate by the offset of
+-  // aOriginOffset
+-  offsetReferenceSpace->mOriginOffsetPosition =
+-      otherOrientation.RotatePoint(mOriginOffsetPosition) +
+-      aOriginOffset.RawPosition();
++  // https://immersive-web.github.io/webxr/#dom-xrreferencespace-getoffsetreferencespace
++  // Set offsetSpace’s origin offset to the result of multiplying base’s origin offset by
++  // originOffset in the relevant realm of base.
++  offsetReferenceSpace->mOriginOffset = mOriginOffset * aOffsetTransform.RawTransform();
+ 
+   return offsetReferenceSpace.forget();
+ }
+diff --git a/dom/vr/XRRigidTransform.cpp b/dom/vr/XRRigidTransform.cpp
+index d29937c56a..c900587f4f 100644
+--- a/dom/vr/XRRigidTransform.cpp
++++ b/dom/vr/XRRigidTransform.cpp
+@@ -95,6 +95,10 @@ gfx::PointDouble3D XRRigidTransform::RawPosition() const {
+   return mRawPosition;
+ }
+ 
++gfx::Matrix4x4Double XRRigidTransform::RawTransform() const {
++  return mRawTransformMatrix;
++}
++
+ void XRRigidTransform::Update(const gfx::PointDouble3D& aPosition,
+                               const gfx::QuaternionDouble& aOrientation) {
+   mNeedsUpdate = true;
+diff --git a/dom/vr/XRRigidTransform.h b/dom/vr/XRRigidTransform.h
+index defeebe13d..878f4e8b5e 100644
+--- a/dom/vr/XRRigidTransform.h
++++ b/dom/vr/XRRigidTransform.h
+@@ -32,6 +32,7 @@ class XRRigidTransform final : public nsWrapperCache {
+   XRRigidTransform& operator=(const XRRigidTransform& aOther);
+   gfx::QuaternionDouble RawOrientation() const;
+   gfx::PointDouble3D RawPosition() const;
++  gfx::Matrix4x4Double RawTransform() const;
+   void Update(const gfx::PointDouble3D& aPosition,
+               const gfx::QuaternionDouble& aOrientation);
+   void Update(const gfx::Matrix4x4Double& aTransform);
+diff --git a/dom/vr/XRSpace.cpp b/dom/vr/XRSpace.cpp
+index 1f6449e870..e74d01be75 100644
+--- a/dom/vr/XRSpace.cpp
++++ b/dom/vr/XRSpace.cpp
+@@ -28,9 +28,7 @@ XRSpace::XRSpace(nsIGlobalObject* aParent, XRSession* aSession,
+                  XRNativeOrigin* aNativeOrigin)
+     : DOMEventTargetHelper(aParent),
+       mSession(aSession),
+-      mNativeOrigin(aNativeOrigin),
+-      mOriginOffsetPosition(0.0f, 0.0f, 0.0f),
+-      mOriginOffsetOrientation(0.0f, 0.0f, 0.0f, 1.0f) {}
++      mNativeOrigin(aNativeOrigin) {}
+ 
+ JSObject* XRSpace::WrapObject(JSContext* aCx,
+                               JS::Handle<JSObject*> aGivenProto) {
+@@ -39,25 +37,18 @@ JSObject* XRSpace::WrapObject(JSContext* aCx,
+ 
+ XRSession* XRSpace::GetSession() const { return mSession; }
+ 
+-gfx::QuaternionDouble XRSpace::GetEffectiveOriginOrientation() const {
+-  gfx::QuaternionDouble orientation =
+-      mNativeOrigin->GetOrientation() * mOriginOffsetOrientation;
+-  return orientation;
+-}
+-
+-gfx::PointDouble3D XRSpace::GetEffectiveOriginPosition() const {
+-  gfx::PointDouble3D position;
+-  position = mNativeOrigin->GetPosition();
+-  position = mOriginOffsetOrientation.RotatePoint(position);
+-  position += mOriginOffsetPosition;
+-  return position;
++gfx::Matrix4x4Double XRSpace::GetNativeOriginTransform() const {
++  if (!mNativeOrigin) {
++    return {};
++  }
++  gfx::Matrix4x4Double transform;
++  transform.SetRotationFromQuaternion(mNativeOrigin->GetOrientation());
++  transform.PostTranslate(mNativeOrigin->GetPosition());
++  return transform;
+ }
+ 
+ gfx::Matrix4x4Double XRSpace::GetEffectiveOriginTransform() const {
+-  gfx::Matrix4x4Double transform;
+-  transform.SetRotationFromQuaternion(GetEffectiveOriginOrientation());
+-  transform.PostTranslate(GetEffectiveOriginPosition());
+-  return transform;
++  return GetNativeOriginTransform() * mOriginOffset;
+ }
+ 
+ bool XRSpace::IsPositionEmulated() const {
+diff --git a/dom/vr/XRSpace.h b/dom/vr/XRSpace.h
+index a87480857e..ff1efc2a01 100644
+--- a/dom/vr/XRSpace.h
++++ b/dom/vr/XRSpace.h
+@@ -34,8 +34,7 @@ class XRSpace : public DOMEventTargetHelper {
+   XRNativeOrigin* GetNativeOrigin() const;
+ 
+   // Non webIDL Members
+-  gfx::QuaternionDouble GetEffectiveOriginOrientation() const;
+-  gfx::PointDouble3D GetEffectiveOriginPosition() const;
++  gfx::Matrix4x4Double GetNativeOriginTransform() const;
+   gfx::Matrix4x4Double GetEffectiveOriginTransform() const;
+   virtual bool IsPositionEmulated() const;
+ 
+@@ -47,8 +46,7 @@ class XRSpace : public DOMEventTargetHelper {
+ 
+   // https://immersive-web.github.io/webxr/#xrspace-origin-offset
+   // Origin Offset, represented as a rigid transform
+-  gfx::PointDouble3D mOriginOffsetPosition;
+-  gfx::QuaternionDouble mOriginOffsetOrientation;
++  gfx::Matrix4x4Double mOriginOffset;
+ };
+ 
+ }  // namespace mozilla::dom
+-- 
+2.40.1
+

--- a/gecko-127.0.1/0002-Disable-ogg-sandboxing.patch
+++ b/gecko-127.0.1/0002-Disable-ogg-sandboxing.patch
@@ -1,0 +1,15 @@
+diff --git a/toolkit/moz.configure b/toolkit/moz.configure
+index 2e56fa46ce..7d815536e3 100644
+--- a/toolkit/moz.configure
++++ b/toolkit/moz.configure
+@@ -2570,7 +2570,6 @@ set_define("MOZ_HAS_REMOTE", has_remote)
+ def wasm_sandboxing_libraries():
+     return (
+         "graphite",
+-        "ogg",
+         "hunspell",
+         "expat",
+         "woff2",
+-- 
+2.40.1
+

--- a/gecko-127.0.1/0002-Disable-ogg-sandboxing.patch~
+++ b/gecko-127.0.1/0002-Disable-ogg-sandboxing.patch~
@@ -1,0 +1,15 @@
+diff --git a/toolkit/moz.configure b/toolkit/moz.configure
+index 2e56fa46ce..7d815536e3 100644
+--- a/toolkit/moz.configure
++++ b/toolkit/moz.configure
+@@ -2547,7 +2547,6 @@ set_define("MOZ_HAS_REMOTE", has_remote)
+ def wasm_sandboxing_libraries():
+     return (
+         "graphite",
+-        "ogg",
+         "hunspell",
+         "expat",
+         "woff2",
+-- 
+2.40.1
+

--- a/gecko-127.0.1/0003-GetOffsetReferenceSpace-invert-the-order-of-the-matr.patch
+++ b/gecko-127.0.1/0003-GetOffsetReferenceSpace-invert-the-order-of-the-matr.patch
@@ -1,0 +1,16 @@
+diff --git a/dom/vr/XRReferenceSpace.cpp b/dom/vr/XRReferenceSpace.cpp
+index c442a916c6..0edeb36541 100644
+--- a/dom/vr/XRReferenceSpace.cpp
++++ b/dom/vr/XRReferenceSpace.cpp
+@@ -24,7 +24,7 @@ already_AddRefed<XRReferenceSpace> XRReferenceSpace::GetOffsetReferenceSpace(
+   // https://immersive-web.github.io/webxr/#dom-xrreferencespace-getoffsetreferencespace
+   // Set offsetSpace’s origin offset to the result of multiplying base’s origin offset by
+   // originOffset in the relevant realm of base.
+-  offsetReferenceSpace->mOriginOffset = mOriginOffset * aOffsetTransform.RawTransform();
++  offsetReferenceSpace->mOriginOffset = aOffsetTransform.RawTransform() * mOriginOffset;
+ 
+   return offsetReferenceSpace.forget();
+ }
+-- 
+2.40.1
+

--- a/gecko-127.0.1/0004-Invert-the-matrix-multiplication-order-in-BoundedRef.patch
+++ b/gecko-127.0.1/0004-Invert-the-matrix-multiplication-order-in-BoundedRef.patch
@@ -1,0 +1,16 @@
+diff --git a/dom/vr/XRBoundedReferenceSpace.cpp b/dom/vr/XRBoundedReferenceSpace.cpp
+index 200a2539f8..d1a37fa58f 100644
+--- a/dom/vr/XRBoundedReferenceSpace.cpp
++++ b/dom/vr/XRBoundedReferenceSpace.cpp
+@@ -57,7 +57,7 @@ XRBoundedReferenceSpace::GetOffsetReferenceSpace(
+   // https://immersive-web.github.io/webxr/#dom-xrreferencespace-getoffsetreferencespace
+   // Set offsetSpace’s origin offset to the result of multiplying base’s origin offset
+   // by originOffset in the relevant realm of base.
+-  offsetReferenceSpace->mOriginOffset = mOriginOffset * aOffsetTransform.RawTransform();
++  offsetReferenceSpace->mOriginOffset = aOffsetTransform.RawTransform() * mOriginOffset;
+ 
+   return offsetReferenceSpace.forget();
+ }
+-- 
+2.40.1
+

--- a/gecko-127.0.1/0005-Use-eye-transform-instead-of-translation-in-external.patch
+++ b/gecko-127.0.1/0005-Use-eye-transform-instead-of-translation-in-external.patch
@@ -1,0 +1,232 @@
+diff --git a/dom/vr/VRServiceTest.cpp b/dom/vr/VRServiceTest.cpp
+index 4e7691638d..a42f1d687c 100644
+--- a/dom/vr/VRServiceTest.cpp
++++ b/dom/vr/VRServiceTest.cpp
+@@ -90,10 +90,15 @@ void VRMockDisplay::Create() {
+   state.eyeResolution.width = 1836;   // 1080 * 1.7
+   state.eyeResolution.height = 2040;  // 1200 * 1.7
+ 
++  float identity[16] = { 
++      1.0f, 0.0f, 0.0f, 0.0f,
++      0.0f, 1.0f, 0.0f, 0.0f,
++      0.0f, 0.0f, 1.0f, 0.0f,
++      0.0f, 0.0f, 0.0f, 1.0f
++  };
++
+   for (uint32_t eye = 0; eye < VRDisplayState::NumEyes; ++eye) {
+-    state.eyeTranslation[eye].x = 0.0f;
+-    state.eyeTranslation[eye].y = 0.0f;
+-    state.eyeTranslation[eye].z = 0.0f;
++    memcpy(state.eyeTransform[eye], identity, sizeof(identity));
+     state.eyeFOV[eye] = gfx::VRFieldOfView(45.0, 45.0, 45.0, 45.0);
+   }
+ 
+@@ -101,25 +106,8 @@ void VRMockDisplay::Create() {
+   state.stageSize.width = 1.0f;
+   state.stageSize.height = 1.0f;
+ 
+-  state.sittingToStandingTransform[0] = 1.0f;
+-  state.sittingToStandingTransform[1] = 0.0f;
+-  state.sittingToStandingTransform[2] = 0.0f;
+-  state.sittingToStandingTransform[3] = 0.0f;
+-
+-  state.sittingToStandingTransform[4] = 0.0f;
+-  state.sittingToStandingTransform[5] = 1.0f;
+-  state.sittingToStandingTransform[6] = 0.0f;
+-  state.sittingToStandingTransform[7] = 0.0f;
+-
+-  state.sittingToStandingTransform[8] = 0.0f;
+-  state.sittingToStandingTransform[9] = 0.0f;
+-  state.sittingToStandingTransform[10] = 1.0f;
+-  state.sittingToStandingTransform[11] = 0.0f;
+-
+-  state.sittingToStandingTransform[12] = 0.0f;
++  memcpy(state.sittingToStandingTransform, identity, sizeof(identity));
+   state.sittingToStandingTransform[13] = 0.75f;
+-  state.sittingToStandingTransform[14] = 0.0f;
+-  state.sittingToStandingTransform[15] = 1.0f;
+ 
+   VRHMDSensorState& sensorState = SensorState();
+   gfx::Quaternion rot;
+@@ -216,9 +204,9 @@ void VRMockDisplay::SetEyeOffset(VREye aEye, double aOffsetX, double aOffsetY,
+                                      ? gfx::VRDisplayState::Eye_Left
+                                      : gfx::VRDisplayState::Eye_Right;
+   VRDisplayState& state = DisplayState();
+-  state.eyeTranslation[eye].x = (float)aOffsetX;
+-  state.eyeTranslation[eye].y = (float)aOffsetY;
+-  state.eyeTranslation[eye].z = (float)aOffsetZ;
++  state.eyeTransform[eye][12] = (float)aOffsetX;
++  state.eyeTransform[eye][13] = (float)aOffsetY;
++  state.eyeTransform[eye][14] = (float)aOffsetZ;
+ }
+ 
+ bool VRMockDisplay::CapPosition() const {
+diff --git a/dom/vr/XRFrame.cpp b/dom/vr/XRFrame.cpp
+index 1561d36eb0..1e41a72500 100644
+--- a/dom/vr/XRFrame.cpp
++++ b/dom/vr/XRFrame.cpp
+@@ -11,6 +11,7 @@
+ #include "mozilla/dom/XRView.h"
+ #include "mozilla/dom/XRReferenceSpace.h"
+ #include "VRDisplayClient.h"
++#define VRB_ERROR(format, ...) __android_log_print(ANDROID_LOG_ERROR, "VRB", format, ##__VA_ARGS__);
+ 
+ namespace mozilla::dom {
+ 
+@@ -86,20 +87,13 @@ already_AddRefed<XRViewerPose> XRFrame::GetViewerPose(
+     viewerPose = mSession->PooledViewerPose(headTransform, emulatedPosition);
+ 
+     auto updateEye = [&](int32_t viewIndex, gfx::VRDisplayState::Eye eye) {
+-      auto offset = displayInfo.GetEyeTranslation(eye);
+-      auto eyeFromHead = gfx::Matrix4x4Double::Translation(
+-          gfx::PointDouble3D(offset.x, offset.y, offset.z));
+-      auto eyeTransform = eyeFromHead * headTransform;
+-      gfx::PointDouble3D eyePosition;
+-      gfx::QuaternionDouble eyeRotation;
+-      gfx::PointDouble3D eyeScale;
+-      eyeTransform.Decompose(eyePosition, eyeRotation, eyeScale);
++      auto eyeFromHead = displayInfo.GetEyeTransform(eye);
++      auto viewTransform = eyeFromHead * headTransform;
+ 
+       const gfx::VRFieldOfView fov = displayInfo.mDisplayState.eyeFOV[eye];
+       gfx::Matrix4x4 projection =
+           fov.ConstructProjectionMatrix(depthNear, depthFar, true);
+-      viewerPose->GetEye(viewIndex)->Update(eyePosition, eyeRotation,
+-                                            projection);
++      viewerPose->GetEye(viewIndex)->Update(viewTransform, projection);
+     };
+ 
+     updateEye(0, gfx::VRDisplayState::Eye_Left);
+@@ -118,8 +112,7 @@ already_AddRefed<XRViewerPose> XRFrame::GetViewerPose(
+ 
+     viewerPose =
+         mSession->PooledViewerPose(gfx::Matrix4x4Double(), emulatedPosition);
+-    viewerPose->GetEye(0)->Update(gfx::PointDouble3D(), gfx::QuaternionDouble(),
+-                                  projection);
++    viewerPose->GetEye(0)->Update(gfx::Matrix4x4Double(), projection);
+   }
+ 
+   return viewerPose.forget();
+diff --git a/dom/vr/XRView.cpp b/dom/vr/XRView.cpp
+index c1ff18004e..0e7e5c962d 100644
+--- a/dom/vr/XRView.cpp
++++ b/dom/vr/XRView.cpp
+@@ -20,7 +20,7 @@ NS_IMPL_CYCLE_COLLECTION_WRAPPERCACHE_WITH_JS_MEMBERS(XRView,
+ XRView::XRView(nsISupports* aParent, const XREye& aEye)
+     : mParent(aParent),
+       mEye(aEye),
+-
++      mEyeTransform(gfx::Matrix4x4Double()),
+       mJSProjectionMatrix(nullptr) {
+   mozilla::HoldJSObjects(this);
+ }
+@@ -32,14 +32,12 @@ JSObject* XRView::WrapObject(JSContext* aCx,
+   return XRView_Binding::Wrap(aCx, this, aGivenProto);
+ }
+ 
+-void XRView::Update(const gfx::PointDouble3D& aPosition,
+-                    const gfx::QuaternionDouble& aOrientation,
++void XRView::Update(const gfx::Matrix4x4Double& aEyeTransform,
+                     const gfx::Matrix4x4& aProjectionMatrix) {
+-  mPosition = aPosition;
+-  mOrientation = aOrientation;
++  mEyeTransform = aEyeTransform;
+   mProjectionMatrix = aProjectionMatrix;
+   if (mTransform) {
+-    mTransform->Update(aPosition, aOrientation);
++    mTransform->Update(mEyeTransform);
+   }
+   if (aProjectionMatrix != mProjectionMatrix) {
+     mProjectionNeedsUpdate = true;
+@@ -70,7 +68,7 @@ void XRView::GetProjectionMatrix(JSContext* aCx,
+ 
+ already_AddRefed<XRRigidTransform> XRView::GetTransform(ErrorResult& aRv) {
+   if (!mTransform) {
+-    mTransform = new XRRigidTransform(mParent, mPosition, mOrientation);
++    mTransform = new XRRigidTransform(mParent, mEyeTransform);
+   }
+   RefPtr<XRRigidTransform> transform = mTransform;
+   return transform.forget();
+diff --git a/dom/vr/XRView.h b/dom/vr/XRView.h
+index 157e489022..5afe0b0617 100644
+--- a/dom/vr/XRView.h
++++ b/dom/vr/XRView.h
+@@ -24,8 +24,7 @@ class XRView final : public nsWrapperCache {
+ 
+   explicit XRView(nsISupports* aParent, const XREye& aEye);
+ 
+-  void Update(const gfx::PointDouble3D& aPosition,
+-              const gfx::QuaternionDouble& aOrientation,
++  void Update(const gfx::Matrix4x4Double& aEyeTransform,
+               const gfx::Matrix4x4& aProjectionMatrix);
+   // WebIDL Boilerplate
+   nsISupports* GetParentObject() const { return mParent; }
+@@ -43,8 +42,7 @@ class XRView final : public nsWrapperCache {
+ 
+   nsCOMPtr<nsISupports> mParent;
+   XREye mEye;
+-  gfx::PointDouble3D mPosition;
+-  gfx::QuaternionDouble mOrientation;
++  gfx::Matrix4x4Double mEyeTransform;
+   gfx::Matrix4x4 mProjectionMatrix;
+   JS::Heap<JSObject*> mJSProjectionMatrix;
+   bool mProjectionNeedsUpdate = true;
+diff --git a/gfx/vr/external_api/moz_external_vr.h b/gfx/vr/external_api/moz_external_vr.h
+index 1777c57b9b..7c69aa044c 100644
+--- a/gfx/vr/external_api/moz_external_vr.h
++++ b/gfx/vr/external_api/moz_external_vr.h
+@@ -48,7 +48,7 @@ namespace gfx {
+ // running at the same time? Or...what if we have multiple
+ // release builds running on same machine? (Bug 1563232)
+ #define SHMEM_VERSION "0.0.11"
+-static const int32_t kVRExternalVersion = 18;
++static const int32_t kVRExternalVersion = 19;
+ 
+ // We assign VR presentations to groups with a bitmask.
+ // Currently, we will only display either content or chrome.
+@@ -344,7 +344,7 @@ struct VRDisplayState {
+   VRDisplayCapabilityFlags capabilityFlags;
+   VRDisplayBlendMode blendMode;
+   VRFieldOfView eyeFOV[VRDisplayState::NumEyes];
+-  Point3D_POD eyeTranslation[VRDisplayState::NumEyes];
++  float eyeTransform[VRDisplayState::NumEyes][16];
+   IntSize_POD eyeResolution;
+   float nativeFramebufferScaleFactor;
+   bool suppressFrames;
+diff --git a/gfx/vr/gfxVR.cpp b/gfx/vr/gfxVR.cpp
+index ed1c6d32d6..b2a385fec9 100644
+--- a/gfx/vr/gfxVR.cpp
++++ b/gfx/vr/gfxVR.cpp
+@@ -72,9 +72,17 @@ const IntSize VRDisplayInfo::SuggestedEyeResolution() const {
+ }
+ 
+ const Point3D VRDisplayInfo::GetEyeTranslation(uint32_t whichEye) const {
+-  return Point3D(mDisplayState.eyeTranslation[whichEye].x,
+-                 mDisplayState.eyeTranslation[whichEye].y,
+-                 mDisplayState.eyeTranslation[whichEye].z);
++  return Point3D(mDisplayState.eyeTransform[whichEye][12],
++                 mDisplayState.eyeTransform[whichEye][13],
++                 mDisplayState.eyeTransform[whichEye][14]);
++}
++
++const Matrix4x4Double VRDisplayInfo::GetEyeTransform(uint32_t whichEye) const {
++  Matrix4x4Double m;
++  for (int i = 0; i < 16; ++i) {
++    m.components[i] = static_cast<double>(mDisplayState.eyeTransform[whichEye][i]);
++  }
++  return m;
+ }
+ 
+ const Size VRDisplayInfo::GetStageSize() const {
+diff --git a/gfx/vr/gfxVR.h b/gfx/vr/gfxVR.h
+index d4d772b6a2..f9c130c169 100644
+--- a/gfx/vr/gfxVR.h
++++ b/gfx/vr/gfxVR.h
+@@ -65,6 +65,7 @@ struct VRDisplayInfo {
+ 
+   const IntSize SuggestedEyeResolution() const;
+   const Point3D GetEyeTranslation(uint32_t whichEye) const;
++  const Matrix4x4Double GetEyeTransform(uint32_t whichEye) const;
+   const VRFieldOfView& GetEyeFOV(uint32_t whichEye) const {
+     return mDisplayState.eyeFOV[whichEye];
+   }

--- a/gecko-127.0.1/0006-Do-not-set-the-docShell-as-inactive-twice-in-a-row.patch
+++ b/gecko-127.0.1/0006-Do-not-set-the-docShell-as-inactive-twice-in-a-row.patch
@@ -1,0 +1,14 @@
+diff --git a/mobile/android/modules/geckoview/GeckoViewContent.sys.mjs b/mobile/android/modules/geckoview/GeckoViewContent.sys.mjs
+index fd339e3d88..c71a5325f7 100644
+--- a/mobile/android/modules/geckoview/GeckoViewContent.sys.mjs
++++ b/mobile/android/modules/geckoview/GeckoViewContent.sys.mjs
+@@ -210,7 +210,8 @@ export class GeckoViewContent extends GeckoViewModule {
+         this.sendToAllChildren(aEvent, aData);
+         break;
+       case "GeckoView:SetActive":
+-        this.browser.docShellIsActive = !!aData.active;
++        if (this.browser.docShellIsActive != !!aData.active)
++          this.browser.docShellIsActive = !!aData.active;
+         break;
+       case "GeckoView:SetFocused":
+         if (aData.focused) {

--- a/gecko-127.0.1/0007-Fix-YouTube-media-stopping-when-closing-a-window.patch
+++ b/gecko-127.0.1/0007-Fix-YouTube-media-stopping-when-closing-a-window.patch
@@ -1,0 +1,20 @@
+diff --git a/dom/base/nsGlobalWindowOuter.cpp b/dom/base/nsGlobalWindowOuter.cpp
+index 97d9671758..8fe8b656ca 100644
+--- a/dom/base/nsGlobalWindowOuter.cpp
++++ b/dom/base/nsGlobalWindowOuter.cpp
+@@ -6076,6 +6076,7 @@ void nsGlobalWindowOuter::FinalClose() {
+   // complete _two_ round-trips to the event loop before the call to
+   // ReallyCloseWindow. This allows setTimeout handlers that are set after
+   // FinalClose() is called to run before the window is torn down.
++  /*
+   nsCOMPtr<nsPIDOMWindowInner> entryWindow =
+       do_QueryInterface(GetEntryGlobal());
+   bool indirect = entryWindow && entryWindow->GetOuterWindow() == this;
+@@ -6084,6 +6085,7 @@ void nsGlobalWindowOuter::FinalClose() {
+   } else {
+     mHavePendingClose = true;
+   }
++  */
+ }
+ 
+ void nsGlobalWindowOuter::ReallyCloseWindow() {

--- a/gecko-127.0.1/0009-Prevent-crashes-if-permissions-are-missing.patch
+++ b/gecko-127.0.1/0009-Prevent-crashes-if-permissions-are-missing.patch
@@ -1,0 +1,90 @@
+diff --git a/mobile/android/exoplayer2/src/main/java/org/mozilla/thirdparty/com/google/android/exoplayer2/WakeLockManager.java b/mobile/android/exoplayer2/src/main/java/org/mozilla/thirdparty/com/google/android/exoplayer2/WakeLockManager.java
+index 368eb8aa0d..90bfaffba6 100644
+--- a/mobile/android/exoplayer2/src/main/java/org/mozilla/thirdparty/com/google/android/exoplayer2/WakeLockManager.java
++++ b/mobile/android/exoplayer2/src/main/java/org/mozilla/thirdparty/com/google/android/exoplayer2/WakeLockManager.java
+@@ -15,10 +15,13 @@
+  */
+ package org.mozilla.thirdparty.com.google.android.exoplayer2;
+ 
++import android.Manifest;
+ import android.annotation.SuppressLint;
+ import android.content.Context;
++import android.content.pm.PackageManager;
+ import android.os.PowerManager;
+ import android.os.PowerManager.WakeLock;
++import android.os.Process;
+ import androidx.annotation.Nullable;
+ import org.mozilla.thirdparty.com.google.android.exoplayer2.util.Log;
+ 
+@@ -39,8 +42,12 @@ import org.mozilla.thirdparty.com.google.android.exoplayer2.util.Log;
+   private boolean stayAwake;
+ 
+   public WakeLockManager(Context context) {
+-    powerManager =
+-        (PowerManager) context.getApplicationContext().getSystemService(Context.POWER_SERVICE);
++    // Prevent a crash if the {@link android.Manifest.permission#WAKE_LOCK} permission has not been granted.
++    if (context.checkPermission(Manifest.permission.WAKE_LOCK, Process.myPid(), Process.myUid()) == PackageManager.PERMISSION_GRANTED) {
++      powerManager = (PowerManager) context.getApplicationContext().getSystemService(Context.POWER_SERVICE);
++    } else {
++      powerManager = null;
++    }
+   }
+ 
+   /**
+diff --git a/mobile/android/exoplayer2/src/main/java/org/mozilla/thirdparty/com/google/android/exoplayer2/util/Util.java b/mobile/android/exoplayer2/src/main/java/org/mozilla/thirdparty/com/google/android/exoplayer2/util/Util.java
+index 4d7d8014dd..456d1d04d6 100644
+--- a/mobile/android/exoplayer2/src/main/java/org/mozilla/thirdparty/com/google/android/exoplayer2/util/Util.java
++++ b/mobile/android/exoplayer2/src/main/java/org/mozilla/thirdparty/com/google/android/exoplayer2/util/Util.java
+@@ -168,10 +168,16 @@ public final class Util {
+    */
+   @Nullable
+   public static ComponentName startForegroundService(Context context, Intent intent) {
+-    if (Util.SDK_INT >= 26) {
+-      return context.startForegroundService(intent);
+-    } else {
+-      return context.startService(intent);
++    // Prevent a crash if the {@link android.Manifest.permission#FOREGROUND_SERVICE} permission has not been granted.
++    try {
++      if (Util.SDK_INT >= 26) {
++        return context.startForegroundService(intent);
++      } else {
++        return context.startService(intent);
++      }
++    } catch (Exception e) {
++      Log.e(TAG, "Error when staring foreground service: " + e.getMessage());
++      return null;
+     }
+   }
+ 
+diff --git a/mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoAppShell.java b/mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoAppShell.java
+index 568fc3a0bb..5366969b27 100644
+--- a/mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoAppShell.java
++++ b/mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoAppShell.java
+@@ -5,6 +5,7 @@
+ 
+ package org.mozilla.gecko;
+ 
++import android.Manifest;
+ import android.annotation.SuppressLint;
+ import android.annotation.TargetApi;
+ import android.app.ActivityManager;
+@@ -44,6 +45,7 @@ import android.os.Debug;
+ import android.os.LocaleList;
+ import android.os.Looper;
+ import android.os.PowerManager;
++import android.os.Process;
+ import android.os.Vibrator;
+ import android.provider.Settings;
+ import android.text.TextUtils;
+@@ -563,6 +565,11 @@ public class GeckoAppShell {
+   @SuppressLint("Wakelock") // We keep the wake lock independent from the function
+   // scope, so we need to suppress the linter warning.
+   private static void setWakeLockState(final String lock, final int state) {
++    // Prevent a crash if the {@link android.Manifest.permission#WAKE_LOCK} permission has not been granted.
++    if (getApplicationContext().checkPermission(Manifest.permission.WAKE_LOCK, Process.myPid(), Process.myUid()) != PackageManager.PERMISSION_GRANTED) {
++      return;
++    }
++
+     if (sWakeLocks == null) {
+       sWakeLocks = new SimpleArrayMap<>(WAKE_LOCKS_COUNT);
+     }

--- a/gecko-127.0.1/0010-webxr-Support-Pico4-controllers.patch
+++ b/gecko-127.0.1/0010-webxr-Support-Pico4-controllers.patch
@@ -1,0 +1,44 @@
+diff --git a/dom/vr/XRInputSource.cpp b/dom/vr/XRInputSource.cpp
+index 8cf2849d1c..4bc66efbbe 100644
+--- a/dom/vr/XRInputSource.cpp
++++ b/dom/vr/XRInputSource.cpp
+@@ -110,6 +110,12 @@ nsTArray<nsString> GetInputSourceProfile(gfx::VRControllerType aType) {
+       id.AssignLiteral("generic-trigger-squeeze-thumbstick");
+       profile.AppendElement(id);
+       break;
++    case gfx::VRControllerType::Pico4:
++      id.AssignLiteral("pico-4");
++      profile.AppendElement(id);
++      id.AssignLiteral("generic-trigger-squeeze-thumbstick");
++      profile.AppendElement(id);
++      break;
+     default:
+       NS_WARNING("Unsupported XR input source profile.\n");
+       break;
+diff --git a/gfx/vr/VRDisplayClient.cpp b/gfx/vr/VRDisplayClient.cpp
+index 914fb05893..02629b85ae 100644
+--- a/gfx/vr/VRDisplayClient.cpp
++++ b/gfx/vr/VRDisplayClient.cpp
+@@ -419,6 +419,7 @@ void VRDisplayClient::GamepadMappingForWebVR(
+       aControllerState.numAxes = 2;
+       break;
+     case VRControllerType::PicoNeo2:
++    case VRControllerType::Pico4:
+       aControllerState.buttonPressed =
+           ShiftButtonBitForNewSlot(0, 3) | ShiftButtonBitForNewSlot(1, 0) |
+           ShiftButtonBitForNewSlot(2, 1) | ShiftButtonBitForNewSlot(3, 4) |
+diff --git a/gfx/vr/external_api/moz_external_vr.h b/gfx/vr/external_api/moz_external_vr.h
+index 7c69aa044c..91785ab335 100644
+--- a/gfx/vr/external_api/moz_external_vr.h
++++ b/gfx/vr/external_api/moz_external_vr.h
+@@ -151,6 +151,7 @@ enum class VRControllerType : uint8_t {
+   PicoGaze,
+   PicoG2,
+   PicoNeo2,
++  Pico4,
+   _end
+ };
+ 
+-- 
+2.40.1
+

--- a/gecko-127.0.1/0012-Fix-for-Delight-video-player.patch
+++ b/gecko-127.0.1/0012-Fix-for-Delight-video-player.patch
@@ -1,0 +1,23 @@
+diff --git a/gfx/vr/VRManager.cpp b/gfx/vr/VRManager.cpp
+index 2157439b92b1..e70a04fc2b55 100644
+--- a/gfx/vr/VRManager.cpp
++++ b/gfx/vr/VRManager.cpp
+@@ -567,6 +567,15 @@ void VRManager::DetectRuntimes() {
+     // after installing or removing an XR device
+     // runtime.
+     DispatchRuntimeCapabilitiesUpdate();
++    // FIXME: this should not be done here. The device enumeration is normally triggered
++    // by the XRSystem once it gets the permission to start an XRSession. However we have
++    // noticed that this does not work in some cases, like the DelightVR player used to
++    // play immersive videos in tons of sites. WebXR applications issue permission requests
++    // as the webpage is loaded, meaning that by the time the user clicks on EnterVR-like
++    // button the devices are already enumerated. However in the case of DelightVR that only
++    // happens when the user already clicks on play. For some unknown reason, that's too late,
++    // probably the WebGL context is not properly already assigned to the newly enumerated device.
++    EnumerateDevices();
+     return;
+   }
+   mRuntimeDetectionRequested = true;
+-- 
+2.35.1
+

--- a/gecko-127.0.1/0015-webxr-Support-Quest3-controllers.patch
+++ b/gecko-127.0.1/0015-webxr-Support-Quest3-controllers.patch
@@ -1,0 +1,47 @@
+diff --git a/dom/vr/XRInputSource.cpp b/dom/vr/XRInputSource.cpp
+index 4bc66efbbe..16ff32a40f 100644
+--- a/dom/vr/XRInputSource.cpp
++++ b/dom/vr/XRInputSource.cpp
+@@ -116,6 +116,16 @@ nsTArray<nsString> GetInputSourceProfile(gfx::VRControllerType aType) {
+       id.AssignLiteral("generic-trigger-squeeze-thumbstick");
+       profile.AppendElement(id);
+       break;
++    case gfx::VRControllerType::MetaQuest3:
++      id.AssignLiteral("meta-quest-touch-plus");
++      profile.AppendElement(id);
++      id.AssignLiteral("oculus-touch-v3");
++      profile.AppendElement(id);
++      id.AssignLiteral("oculus-touch");
++      profile.AppendElement(id);
++      id.AssignLiteral("generic-trigger-squeeze-thumbstick");
++      profile.AppendElement(id);
++      break;
+     default:
+       NS_WARNING("Unsupported XR input source profile.\n");
+       break;
+diff --git a/gfx/vr/VRDisplayClient.cpp b/gfx/vr/VRDisplayClient.cpp
+index 02629b85ae..0a949cb913 100644
+--- a/gfx/vr/VRDisplayClient.cpp
++++ b/gfx/vr/VRDisplayClient.cpp
+@@ -337,7 +337,8 @@ void VRDisplayClient::GamepadMappingForWebVR(
+       aControllerState.numAxes = 2;
+       break;
+     case VRControllerType::OculusTouch2:
+-    case VRControllerType::OculusTouch3: {
++    case VRControllerType::OculusTouch3:
++    case VRControllerType::MetaQuest3: {
+       aControllerState.buttonPressed =
+           ShiftButtonBitForNewSlot(0, 3) | ShiftButtonBitForNewSlot(1, 0) |
+           ShiftButtonBitForNewSlot(2, 1) | ShiftButtonBitForNewSlot(3, 4) |
+diff --git a/gfx/vr/external_api/moz_external_vr.h b/gfx/vr/external_api/moz_external_vr.h
+index 91785ab335..031caa2a51 100644
+--- a/gfx/vr/external_api/moz_external_vr.h
++++ b/gfx/vr/external_api/moz_external_vr.h
+@@ -152,6 +152,7 @@ enum class VRControllerType : uint8_t {
+   PicoG2,
+   PicoNeo2,
+   Pico4,
++  MetaQuest3,
+   _end
+ };
+ 

--- a/gecko-127.0.1/0016-webxr-Support-MagicLeap2-controller.patch
+++ b/gecko-127.0.1/0016-webxr-Support-MagicLeap2-controller.patch
@@ -1,0 +1,50 @@
+diff --git a/dom/vr/XRInputSource.cpp b/dom/vr/XRInputSource.cpp
+index 16ff32a40f..f3beef26d9 100644
+--- a/dom/vr/XRInputSource.cpp
++++ b/dom/vr/XRInputSource.cpp
+@@ -126,6 +126,12 @@ nsTArray<nsString> GetInputSourceProfile(gfx::VRControllerType aType) {
+       id.AssignLiteral("generic-trigger-squeeze-thumbstick");
+       profile.AppendElement(id);
+       break;
++    case gfx::VRControllerType::MagicLeap2:
++      id.AssignLiteral("magicleap-one");
++      profile.AppendElement(id);
++      id.AssignLiteral("generic-trigger-squeeze-thumbstick");
++      profile.AppendElement(id);
++      break;
+     default:
+       NS_WARNING("Unsupported XR input source profile.\n");
+       break;
+diff --git a/gfx/vr/VRDisplayClient.cpp b/gfx/vr/VRDisplayClient.cpp
+index 0a949cb913..36a7b5bb71 100644
+--- a/gfx/vr/VRDisplayClient.cpp
++++ b/gfx/vr/VRDisplayClient.cpp
+@@ -436,6 +436,16 @@ void VRDisplayClient::GamepadMappingForWebVR(
+       aControllerState.numButtons = 6;
+       aControllerState.numAxes = 2;
+       break;
++    case VRControllerType::MagicLeap2:
++      aControllerState.buttonPressed = ShiftButtonBitForNewSlot(0, 2) |
++                                       ShiftButtonBitForNewSlot(1, 0) |
++                                       ShiftButtonBitForNewSlot(2, 1);
++      aControllerState.buttonTouched = ShiftButtonBitForNewSlot(0, 2, true) |
++                                       ShiftButtonBitForNewSlot(1, 0, true) |
++                                       ShiftButtonBitForNewSlot(2, 1, true);
++      aControllerState.numButtons = 3;
++      aControllerState.numAxes = 2;
++      break;
+     default:
+       // Undefined controller types, we will keep its the same order.
+       break;
+diff --git a/gfx/vr/external_api/moz_external_vr.h b/gfx/vr/external_api/moz_external_vr.h
+index 031caa2a51..1bb2cdd9f8 100644
+--- a/gfx/vr/external_api/moz_external_vr.h
++++ b/gfx/vr/external_api/moz_external_vr.h
+@@ -153,6 +153,7 @@ enum class VRControllerType : uint8_t {
+   PicoNeo2,
+   Pico4,
+   MetaQuest3,
++  MagicLeap2,
+   _end
+ };
+ 

--- a/gecko-127.0.1/0017-webxr-Support-PicoNeo3-controller.patch
+++ b/gecko-127.0.1/0017-webxr-Support-PicoNeo3-controller.patch
@@ -1,0 +1,44 @@
+diff --git a/dom/vr/XRInputSource.cpp b/dom/vr/XRInputSource.cpp
+index f3beef26d9..412206cdf1 100644
+--- a/dom/vr/XRInputSource.cpp
++++ b/dom/vr/XRInputSource.cpp
+@@ -110,6 +110,12 @@ nsTArray<nsString> GetInputSourceProfile(gfx::VRControllerType aType) {
+       id.AssignLiteral("generic-trigger-squeeze-thumbstick");
+       profile.AppendElement(id);
+       break;
++    case gfx::VRControllerType::PicoNeo3:
++      id.AssignLiteral("pico-neo3");
++      profile.AppendElement(id);
++      id.AssignLiteral("generic-trigger-squeeze-thumbstick");
++      profile.AppendElement(id);
++      break;
+     case gfx::VRControllerType::Pico4:
+       id.AssignLiteral("pico-4");
+       profile.AppendElement(id);
+diff --git a/gfx/vr/VRDisplayClient.cpp b/gfx/vr/VRDisplayClient.cpp
+index 36a7b5bb71..2a5af2df3b 100644
+--- a/gfx/vr/VRDisplayClient.cpp
++++ b/gfx/vr/VRDisplayClient.cpp
+@@ -420,6 +420,7 @@ void VRDisplayClient::GamepadMappingForWebVR(
+       aControllerState.numAxes = 2;
+       break;
+     case VRControllerType::PicoNeo2:
++    case VRControllerType::PicoNeo3:
+     case VRControllerType::Pico4:
+       aControllerState.buttonPressed =
+           ShiftButtonBitForNewSlot(0, 3) | ShiftButtonBitForNewSlot(1, 0) |
+diff --git a/gfx/vr/external_api/moz_external_vr.h b/gfx/vr/external_api/moz_external_vr.h
+index 1bb2cdd9f8..4c7405e441 100644
+--- a/gfx/vr/external_api/moz_external_vr.h
++++ b/gfx/vr/external_api/moz_external_vr.h
+@@ -151,6 +151,7 @@ enum class VRControllerType : uint8_t {
+   PicoGaze,
+   PicoG2,
+   PicoNeo2,
++  PicoNeo3,
+   Pico4,
+   MetaQuest3,
+   MagicLeap2,
+-- 
+2.39.2
+


### PR DESCRIPTION
These are the same as for 121.0.1 except for
0008-Bug-1655101-Allow-blit-to-GL_RGB-texture-for-webgl-t.patch
which has already been fixed upstream.