### PR TITLE
EGLSharedSurface implements the SupportCSpaces method

### DIFF
--- a/gecko-128.1.0/0016-SharedSurfaceEGL-Support-CSpaces.patch
+++ b/gecko-128.1.0/0016-SharedSurfaceEGL-Support-CSpaces.patch
@@ -1,0 +1,11 @@
+--- a/gfx/gl/SharedSurfaceEGL.h
++++ b/gfx/gl/SharedSurfaceEGL.h
+@@ -115,6 +115,8 @@ class SurfaceFactory_SurfaceTexture final : public SurfaceFactory {
+  public:
+   explicit SurfaceFactory_SurfaceTexture(GLContext&);
+ 
++  bool SupportsCspaces() const override { return true; }
++
+   virtual UniquePtr<SharedSurface> CreateSharedImpl(
+       const SharedSurfaceDesc& desc) override {
+     return SharedSurface_SurfaceTexture::Create(desc);


### PR DESCRIPTION
In https://phabricator.services.mozilla.com/D207651 a new feature to manage color spaces has been added. As a result, a new virtual method has been defined in the SharedSurface abstract class to indicate whether the implementor supports specific color spaces passed through the creation options.

The implementation considered false as default, so that that all the surfaces implemented in the derived classes would use gfx::ColorSpace2::Display when creating the specific SharedSurface instance. This generic color space would then be determined by the new feature mentioned before, as part of the logic of the WebGLContext::PresentInto function.

However, this change had the (unexpected ?) effect of disabling polling on the SwapChain::Acquire method. The problem is that no matter what color space we pass to the Acquire method, the surface created will have Display. Hence, there won't be a match with the pool's front so that it's set to an empty set.

We are not sure yet whether this is such an expected behavior of the new color management feature, but it's worth filing a bug upstream so that Mozilla folks can evaluate it.